### PR TITLE
ユーザー新規登録・ログイン機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :birthday])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :myoji_kanji, :namae_kanji, :myoji_kana, :namae_kana, :birthday])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,4 +9,5 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,10 @@ class User < ApplicationRecord
   has_many :addresses
   has_many :items
   has_many :purchases
+  validates :nickname, presence: true
+  validates :myoji_kanji, presence: true
+  validates :namae_kanji, presence: true
+  validates :myoji_kana, presence: true
+  validates :namae_kana, presence: true
+  validates :birthday, presence: true
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,30 +2,30 @@
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = render "devise/shared/error_messages", resource: resource
   .field
-    = f.label :ニックネーム
-    = f.text_field :nickname, autofocus: true
+    ニックネーム
+    = f.text_field :nickname, placeholder: "例)ナオ太郎"
   .field
-    = f.label :email
-    = f.email_field :email, autofocus: true, autocomplete: "email"
+    メールアドレス
+    = f.email_field :email, autocomplete: "email", placeholder: "PC・携帯どちらでも可"
   .field
-    = f.label :first_name
-    = f.text_field :first_name, autofocus: true
+    パスワード
+    = f.password_field :password, autocomplete: "new-password", placeholder: "7文字以上"
   .field
-    = f.label :last_name
-    = f.text_field :last_name, autofocus: true
-  .field
-    = f.label :birthday
-    = f.date_select("birthday", start_year: 1995, autofocus: true)
-  .field
-    = f.label :password
-    - if @minimum_password_length
-      %em
-        (#{@minimum_password_length} characters minimum)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-  .field
-    = f.label :password_confirmation
-    %br/
+    パスワード（確認）
     = f.password_field :password_confirmation, autocomplete: "new-password"
+  本人確認
+  %br/
+  安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+  .field
+    お名前（全角）
+    = f.text_field :myoji_kanji, placeholder: "例)福田"
+    = f.text_field :namae_kanji, placeholder: "例)尚"
+  .field
+    お名前カナ（全角）
+    = f.text_field :myoji_kana, placeholder: "例)フクダ"
+    = f.text_field :namae_kana, placeholder: "例)ナオ"
+  .field
+    生年月日
+    = raw sprintf(f.date_select("birthday", use_month_numbers: true, start_year: 1900, date_separator: '%s'), '年', '月')+'日'
   .actions
-    = f.submit "Sign up"
+    = f.submit "次へ進む"

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -52,11 +52,11 @@
             = link_to user_path(current_user) do
               マイページ
       - else
-        %ul.container__bottom__right
-          %li.container__bottom__right__list-left
+        .container__bottom__right
+          .container__bottom__right__new-user
             = link_to new_user_registration_path do
               %i.fa.fa-heart-o
               ユーザー新規登録
-          %li.container__bottom__right__list-right
+          .container__bottom__right__login
             = link_to new_user_session_path do
               ログイン

--- a/db/migrate/20191123065853_devise_create_users.rb
+++ b/db/migrate/20191123065853_devise_create_users.rb
@@ -4,12 +4,15 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.string :nickname,               null: false
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
-      t.string :first_name,             null: false
-      t.string :last_name,              null: false
-      t.date   :birthday,               null: false
+      t.string :nickname,           null: false
+      t.string :email,              null: false
+      t.string :encrypted_password, null: false
+      t.string :myoji_kanji,        null: false
+      t.string :namae_kanji,        null: false
+      t.string :myoji_kana,         null: false
+      t.string :namae_kana,         null: false
+      t.date   :birthday,           null: false
+      t.text   :introduction
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/migrate/20191123071813_create_addresses.rb
+++ b/db/migrate/20191123071813_create_addresses.rb
@@ -2,9 +2,9 @@ class CreateAddresses < ActiveRecord::Migration[5.2]
   def change
     create_table :addresses do |t|
       t.string :postal_code, null: false
-      t.string :prefecture, null: false
-      t.string :city, null: false
-      t.string :address, null: false
+      t.string :prefecture,  null: false
+      t.string :city,        null: false
+      t.string :address,     null: false
       t.string :building
       t.timestamps
       t.references :user, foreign_key: true

--- a/db/migrate/20191126125621_add_introduction_to_users.rb
+++ b/db/migrate/20191126125621_add_introduction_to_users.rb
@@ -1,5 +1,0 @@
-class AddIntroductionToUsers < ActiveRecord::Migration[5.2]
-  def change
-    add_column :users, :introduction, :text
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_26_125621) do
+ActiveRecord::Schema.define(version: 2019_11_23_075920) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "postal_code", null: false
@@ -52,17 +52,19 @@ ActiveRecord::Schema.define(version: 2019_11_26_125621) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "first_name", default: "", null: false
-    t.string "last_name", default: "", null: false
+    t.string "email", null: false
+    t.string "encrypted_password", null: false
+    t.string "myoji_kanji", null: false
+    t.string "namae_kanji", null: false
+    t.string "myoji_kana", null: false
+    t.string "namae_kana", null: false
     t.date "birthday", null: false
+    t.text "introduction"
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "introduction"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# what
ユーザー登録自体はメールアドレスのみで機能することを確認したので、漢字姓名、カナ姓名を追加で登録するように実装します。このプルリクではサーバーサイドが機能するところまで実装します。

## 全体の工程
**1. ユーザーの情報をusersテーブルに登録する（サーバーサイド）**
2. フロントを実装する
3. ユーザーの住所をaddressesテーブルに登録する
4. フロントを実装する（画面遷移を含む）
5. pay.jpを利用しクレジットカード情報を登録する
6. フロントを実装する（登録完了画面などを含む、登録機能全体としてのフロント実装）

サーバーサイドの動きは大きく３段階に分かれているので、それに沿った分割をしています。
また、pay.jpを用いたカード情報の登録は別の開発メンバーが担当しています。

### 今回実装する箇所のステップ
1. 乱暴なやり方ですが、db:dropを実行した後migrationファイルを編集・削除
2. db:create/migrateを実行する。
3. 現状の登録画面にフォームを追加し、データベースに保存できるようにする
4. モデルファイルにバリデーションを追加する
~~5. エラーハンドリングを実装する（保存が失敗した時のリダイレクトやエラー文の表示）~~

2019/11/28追記
deviseの仕組みの理解が進まず、保存に失敗した際にフィールド下部にエラーを表示する方法がわかりませんでした。他に優先度の高いタスクがあるので、現状はデフォルトで用意されているリダイレクトやエラーメッセージで進めます。

# why
本アプリケーションの重要な機能であり、商品の出品や購入にはユーザーの情報が欠かせません。また、入力情報も多いので、エラーハンドリングに注意しながら実装する必要があります。