### PR TITLE
S3の実装

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,5 @@
 class Image < ApplicationRecord
+  mount_uploader :image, ImageUploader
+
   belongs_to :item
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,7 +1,7 @@
 class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
   if Rails.env.development? || Rails.env.test?
@@ -32,9 +32,9 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
 
   # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
+  version :thumb do
+    process resize_to_fit: [180, 180]
+  end
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -38,9 +38,9 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpeg png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -29,3 +29,25 @@ namespace :deploy do
     invoke 'unicorn:restart'
   end
 end
+
+set :linked_files, %w{ config/master.key }
+
+after 'deploy:publishing', 'deploy:restart'
+namespace :deploy do
+  task :restart do
+    invoke 'unicorn:restart'
+  end
+
+  desc 'upload master.key'
+  task :upload do
+    on roles(:app) do |host|
+      if test "[ ! -d #{shared_path}/config ]"
+        execute "mkdir -p #{shared_path}/config"
+      end
+      upload!('config/master.key', "#{shared_path}/config/master.key")
+    end
+  end
+  before :starting, 'deploy:upload'
+  after :finishing, 'deploy:cleanup'
+end
+

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -10,8 +10,8 @@ CarrierWave.configure do |config|
     config.fog_provider = 'fog/aws'
     config.fog_credentials = {
       provider: 'AWS',
-      aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
-      aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       region: 'ap-northeast-1'
     }
     config.fog_directory  = 'panpanpaaan'


### PR DESCRIPTION
## What
出品機能のデプロイ完了後にCarrierwaveおよびmini-magickを用いてAWS S3へ画像の保存ができるようにコーディングする

## Why
本番環境では画像を保存する必要があるが、アプリケーションサーバーへ保存すると容量を圧迫していくため。また、出品機能デプロイ後にスムーズに実装テストをするため。