### PR TITLE
支払い方法の表示ページの体裁調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,4 +24,5 @@
 @import "modules/user-exhibit-items-sold";
 @import "modules/purchases-new";
 @import "modules/breadcrumbs";
+@import "modules/card-new";
 

--- a/app/assets/stylesheets/modules/_card-new.scss
+++ b/app/assets/stylesheets/modules/_card-new.scss
@@ -1,0 +1,9 @@
+#payjp_checkout_box input[type=button] {
+  @include submit-btn();
+  background-color: $red;
+}
+.card-exit {
+  text-align: center;
+  font-weight: bold;
+  font-size: 24px;
+}

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -8,9 +8,6 @@
 
     def new 
       card = Card.where(user_id: current_user.id)
-      if card.present?
-        redirect_to root_path, notice: "登録済みです"
-      end 
     end
   
     def create 
@@ -21,7 +18,7 @@
         customer = Payjp::Customer.create(card: params['payjp-token'])
         @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
         if @card.save
-          redirect_to root_path, notice: 'カードの登録が完了しました'
+          redirect_to action: "new"
         else
           redirect_to action: "create"
         end

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,4 +1,17 @@
-.card__new--btn
-  = form_with url: user_cards_path, method: "post" do
-    :plain
-      <script type="text/javascript" src="https://checkout.pay.jp" class="payjp-button" data-payjp= "3b2af2d309980321d4184814ecd6257e123d9cbe" data-key="pk_test_7a80698bf3309ecfeed80515" data-text="カードを追加する" data-submit-text="追加する"></script>
+= render "layouts/header"
+- breadcrumb :mypage
+= render "layouts/breadcrumbs"
+.background
+  .show-container.clearfix
+    = render "users/side"
+    .show-container__main
+      .show-container__main__header 発送元・お届け先住所変更
+      .show-container__main__container
+        - if @card.present?
+          %p.card-exit 登録済みです
+        - else
+          .card__new--btn
+            = form_with url: user_cards_path, method: "post" do
+              :plain
+                <script type="text/javascript" src="https://checkout.pay.jp" class="payjp-button" data-payjp= "3b2af2d309980321d4184814ecd6257e123d9cbe" data-key="pk_test_7a80698bf3309ecfeed80515" data-text="カードを追加する" data-submit-text="追加する"></script>
+= render "layouts/footer"

--- a/app/views/users/_side.html.haml
+++ b/app/views/users/_side.html.haml
@@ -33,7 +33,7 @@
       = link_to deliver_address_user_path(current_user) do
         %li.mypage-nav__ul__li
           発送元・お届け先住所変更
-      = link_to new_user_card_path(current_user) do
+      = link_to new_user_card_path(current_user), data: {turbolinks: false} do
         %li.mypage-nav__ul__li
           支払い方法
       %li.mypage-nav__ul__li

--- a/app/views/users/_side.html.haml
+++ b/app/views/users/_side.html.haml
@@ -43,6 +43,6 @@
           本人情報確認
       %li.mypage-nav__ul__li
         電話番号の確認
-      = link_to logout_user_path do
+      = link_to logout_user_path(current_user) do
         %li.mypage-nav__ul__li
           ログアウト

--- a/app/views/users/identification.html.haml
+++ b/app/views/users/identification.html.haml
@@ -12,7 +12,7 @@
             %p お客さまの本人情報をご登録ください。  
             %p 登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
             .contents__header__info
-              = link_to "本人確認書類のアップロードについて >", href: "https://www.mercari.com/jp/help_center/article/495/", class: "info-link"
+              = link_to "本人確認書類のアップロードについて >", "https://www.mercari.com/jp/help_center/article/495/", class: "info-link"
           .contents__form-group
             .contents__form-group__label お名前
             %p.regist-text 
@@ -49,6 +49,5 @@
             .contents__btn
               = f.submit "変更する", class: "contents__btn--red"
             .contents__bottom-info
-              = link_to "本人情報の登録について >", href: "https://www.mercari.com/jp/help_center/article/423", class: "info-link"
-
+              = link_to "本人情報の登録について >", "https://www.mercari.com/jp/help_center/article/423", class: "info-link"
 = render "layouts/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
       get :exhibit_items_trading
       get :exhibit_items_sold
     end
-    resources :cards, only: [:new]
+    resources :cards, only: [:new, :create]
   end
 
   resources :signup, only: [:index, :create] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,11 +21,9 @@ Rails.application.routes.draw do
       get :exhibit_items_trading
       get :exhibit_items_sold
     end
-    resources :cards
+    resources :cards, only: [:new]
   end
 
-  get 'cards/new'
-  
   resources :signup, only: [:index, :create] do
     collection do
       get  'step1'


### PR DESCRIPTION
## What
・mypage_sidebarにある支払い方法をクリックして、カード登録済みかどうかを表示
・カードの登録ボタンを初回時にリロードなしで表示できるようにした
・遷移先をmypageにして作業性をあげた

## Why
ユーザーの使用性を高めるため
